### PR TITLE
Update go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module main
+module release-note-page
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect


### PR DESCRIPTION
```
$ go get github.com/menghanl/release-note-page
release-note-page go: downloading github.com/menghanl/release-note-page v0.0.0-20191103190302-275cae16c43b
go get: github.com/menghanl/release-note-page@none updating to
	github.com/menghanl/release-note-page@v0.0.0-20191103190302-275cae16c43b: parsing go.mod:
	module declares its path as: main
	        but was required as: github.com/menghanl/release-note-page
```